### PR TITLE
deps: upgraded test dependencies (jacoco, junit5, assertj)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,25 +19,25 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.9.1</version>
+      <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.1</version>
+      <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.9.1</version>
+      <version>1.9.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.1</version>
+      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -61,7 +61,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <id>default-prepare-agent</id>


### PR DESCRIPTION
This PR upgrades the versions of dependency libraries for test.

- Jacoco : `0.8.8` --> `0.8.10`
- JUnit5
    - Jupiter API : `5.9.1` --> `5.9.3`
    - Jupiter Engine : `5.9.1` --> `5.9.3`
    - Platform : `1.9.1` --> `1.9.3`

At the moment, the latest version of JUnit5 is `5.10.0`, but this version does not support native build.  (The following errors occur.)
```
Error: Classes that should be initialized at run time got initialized during image building:
 org.junit.platform.launcher.core.LauncherConfig was unintentionally initialized at build time. To see why org.junit.platform.launcher.core.LauncherConfig got initialized use --trace-class-initialization=org.junit.platform.launcher.core.LauncherConfig
org.junit.jupiter.engine.config.InstantiatingConfigurationParameterConverter was unintentionally initialized at build time. To see why org.junit.jupiter.engine.config.InstantiatingConfigurationParameterConverter got initialized use --trace-class-initialization=org.junit.jupiter.engine.config.InstantiatingConfigurationParameterConverter
To see how the classes got initialized, use --trace-class-initialization=org.junit.platform.launcher.core.LauncherConfig,org.junit.jupiter.engine.config.InstantiatingConfigurationParameterConverter
```