### PR TITLE
chore,cicd: changed to support only JDK21 or later

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -7,22 +7,21 @@ on:
 jobs:
 
   build:
-    name: Build for GraalVM 22.3 (OpenJDK ${{ matrix.javaver }}) on ${{ matrix.os }}
+    name: Build for GraalVM (OpenJDK ${{ matrix.javaver }}) on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        javaver: [17, 19]
+        javaver: [21]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up GraalVM
+    - name: GitHub Action for GraalVM
       uses: graalvm/setup-graalvm@v1
       with:
-        version: '22.3.0'
         java-version: ${{ matrix.javaver }}
-        components: 'native-image'
+        distribution: 'graalvm'
         github-token: ${{ secrets.GITHUB_TOKEN }}
         native-image-job-reports: 'true'
 

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -15,8 +15,8 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        java-version: '17'
-        distribution: 'temurin'
+        java-version: '21'
+        distribution: 'corretto'
 
     - name: Compile
       run: mvn compile

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -50,7 +50,7 @@
         <version>3.4.1</version>
         <configuration>
           <author>true</author>
-          <source>17</source>
+          <source>21</source>
           <show>protected</show>
           <encoding>UTF-8</encoding>
           <charset>UTF-8</charset>


### PR DESCRIPTION
This PR updates target JDK versions to 21.
Because the planned changes uses features only supported from JDK 21, e.g. Vritual thread, I'll drop the versions less than it.
