### PR TITLE
cicd: changed javadoc github actions to use graalvm, too

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -12,11 +12,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK
-      uses: actions/setup-java@v2
+    - name: GitHub Action for GraalVM
+      uses: graalvm/setup-graalvm@v1
       with:
-        java-version: '21'
-        distribution: 'corretto'
+        java-version: 21
+        distribution: 'graalvm'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Compile
       run: mvn compile


### PR DESCRIPTION
T/O.