### PR TITLE
chore: modified pom.xml not to skip jacoco execution, etc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,12 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!--
+     For changing environment variables in unit tests.
+     This setting is for maven-surefire-plugin but moved here for jacoco.
+     See: https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html
+    -->
+    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
   </properties>
 
   <dependencies>
@@ -93,10 +99,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M7</version>
-        <configuration>
-          <!-- for changing environment variables in unit tests. -->
-          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -132,7 +134,7 @@
             </executions>
             <configuration>
               <fallback>false</fallback>
-              <!-- for changing environment variables in unit tests. -->
+              <!-- For changing environment variables in unit tests. -->
               <buildArgs>
                 -J--add-opens=java.base/java.lang=ALL-UNNAMED
               </buildArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -25,19 +25,19 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.9.3</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.3</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.9.3</version>
+      <version>1.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -136,7 +136,9 @@
               <fallback>false</fallback>
               <!-- For changing environment variables in unit tests. -->
               <buildArgs>
-                -J--add-opens=java.base/java.lang=ALL-UNNAMED
+                <buildArg>-J--add-opens=java.base/java.lang=ALL-UNNAMED</buildArg>
+                <buildArg>--initialize-at-build-time=org.junit.platform.launcher.core.LauncherConfig</buildArg>
+                <buildArg>--initialize-at-build-time=org.junit.jupiter.engine.config.InstantiatingConfigurationParameterConverter</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/src/test/java/com/github/sttk/sabi/errs/ErrHandlerTest.java
+++ b/src/test/java/com/github/sttk/sabi/errs/ErrHandlerTest.java
@@ -48,7 +48,7 @@ public class ErrHandlerTest {
         err.getReason().toString(), occ.getFile(), occ.getLine()));
     });
     Err.addAsyncHandler((err, occ) -> {
-      try { Thread.sleep(20); } catch (Exception e) {}
+      try { Thread.sleep(50); } catch (Exception e) {}
       asyncLogger.add(String.format("4. %s (%s:%d)",
         err.getReason().toString(), occ.getFile(), occ.getLine()));
     });
@@ -60,7 +60,7 @@ public class ErrHandlerTest {
       assertThat(e.getReason()).isInstanceOf(FailToDoSomething.class);
 
       try {
-        Thread.sleep(100);
+        Thread.sleep(200);
       } catch (Exception e2) {}
 
       assertThat(syncLogger).hasSize(2);


### PR DESCRIPTION
I noticed that Jacoco execution for unit test coverages was skipped.
This PR fixes this problem by moving `argLine` for maven-surefire-plugin to properties.

See: https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html

In addition, this PR upgrades versions of JUnit5 modules. However this JUnit5 version caused errors in native build, I added build args to fix this errors.

See: https://junit.org/junit5/docs/5.10.0-RC1/release-notes/#deprecations-and-breaking-changes-2