### PR TITLE
refactor: tightened up the inheritance constraints for classes

### DIFF
--- a/src/main/java/com/github/sttk/sabi/AsyncGroup.java
+++ b/src/main/java/com/github/sttk/sabi/AsyncGroup.java
@@ -13,7 +13,7 @@ package com.github.sttk.sabi;
  * errors occurring during the execution of a {@link Runner} are stored and can be retrieved by
  * their names in a map.
  */
-public interface AsyncGroup {
+public sealed interface AsyncGroup permits com.github.sttk.sabi.internal.AsyncGroupImpl {
 
   /**
    * Represents the reason for a new {@link com.github.sttk.errs.Err} exception object when an

--- a/src/main/java/com/github/sttk/sabi/internal/AsyncGroupImpl.java
+++ b/src/main/java/com/github/sttk/sabi/internal/AsyncGroupImpl.java
@@ -9,7 +9,7 @@ import com.github.sttk.sabi.AsyncGroup;
 import com.github.sttk.sabi.Runner;
 import java.util.Map;
 
-public class AsyncGroupImpl implements AsyncGroup {
+public final class AsyncGroupImpl implements AsyncGroup {
   private ErrEntry errHead;
   private ErrEntry errLast;
   private VthEntry vthHead;

--- a/src/main/java/com/github/sttk/sabi/internal/DataConnContainer.java
+++ b/src/main/java/com/github/sttk/sabi/internal/DataConnContainer.java
@@ -6,7 +6,7 @@ package com.github.sttk.sabi.internal;
 
 import com.github.sttk.sabi.DataConn;
 
-public class DataConnContainer {
+public final class DataConnContainer {
   DataConnContainer prev;
   DataConnContainer next;
   String name;

--- a/src/main/java/com/github/sttk/sabi/internal/DataConnList.java
+++ b/src/main/java/com/github/sttk/sabi/internal/DataConnList.java
@@ -4,7 +4,7 @@
  */
 package com.github.sttk.sabi.internal;
 
-public class DataConnList {
+public final class DataConnList {
   DataConnContainer head;
   DataConnContainer last;
 

--- a/src/main/java/com/github/sttk/sabi/internal/DataHubInner.java
+++ b/src/main/java/com/github/sttk/sabi/internal/DataHubInner.java
@@ -13,10 +13,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class DataHubInner {
+public final class DataHubInner {
 
   static final DataSrcList GLOBAL_DATA_SRC_LIST = new DataSrcList(false);
-  static AtomicBoolean GLOBAL_DATA_SRCS_FIXED = new AtomicBoolean(false);
+  static final AtomicBoolean GLOBAL_DATA_SRCS_FIXED = new AtomicBoolean(false);
 
   public static void usesGlobal(String name, DataSrc ds) {
     if (!GLOBAL_DATA_SRCS_FIXED.get()) {

--- a/src/main/java/com/github/sttk/sabi/internal/DataSrcContainer.java
+++ b/src/main/java/com/github/sttk/sabi/internal/DataSrcContainer.java
@@ -6,7 +6,7 @@ package com.github.sttk.sabi.internal;
 
 import com.github.sttk.sabi.DataSrc;
 
-public class DataSrcContainer {
+public final class DataSrcContainer {
   DataSrcContainer prev;
   DataSrcContainer next;
   boolean local;

--- a/src/main/java/com/github/sttk/sabi/internal/DataSrcList.java
+++ b/src/main/java/com/github/sttk/sabi/internal/DataSrcList.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class DataSrcList {
+public final class DataSrcList {
   DataSrcContainer notSetupHead;
   DataSrcContainer notSetupLast;
   DataSrcContainer didSetupHead;


### PR DESCRIPTION
This PR adds inheritance restrictions to internal classes and the `AsyncGroup` interface, enhancing the robustness of the framework.